### PR TITLE
Fix #47 - Quick fix to make 'Ctrl+V' paste work

### DIFF
--- a/src/codeEditorView.ts
+++ b/src/codeEditorView.ts
@@ -101,11 +101,19 @@ export class CodeEditorView extends TextFileView {
 			['[', 'editor.action.outdentLines'],
 			[']', 'editor.action.indentLines'],
 			['d', 'editor.action.copyLinesDownAction'],
+			['v', 'paste'],
 		]);
 		if (event.ctrlKey) {
 			const triggerName = ctrlMap.get(event.key);
 			if (triggerName) {
-				this.monacoEditor.trigger('', triggerName, null);
+				if (triggerName === 'paste') {
+					navigator.clipboard.readText().then((clipboard) => {
+						this.monacoEditor.trigger('source', triggerName, {text: clipboard });
+					})
+				}
+				else {
+					this.monacoEditor.trigger('source', triggerName, null);
+				}
 			}
 		}
 


### PR DESCRIPTION
Might want to make the whole method async to make the code cleaner and await getting clipboard.
Didn't do it as didn't want to modify the base function too much.