### PR TITLE
Fix keyboard shortcuts being incorrect on macOS

### DIFF
--- a/src/codeEditorView.ts
+++ b/src/codeEditorView.ts
@@ -1,5 +1,5 @@
 
-import { TextFileView, TFile, WorkspaceLeaf } from "obsidian";
+import { Keymap, TextFileView, TFile, WorkspaceLeaf } from "obsidian";
 import { viewType } from "./common";
 import CodeFilesPlugin from "./main";
 import * as monaco from 'monaco-editor'
@@ -106,7 +106,8 @@ export class CodeEditorView extends TextFileView {
 			['d', 'editor.action.copyLinesDownAction'],
 			['v', 'paste'],
 		]);
-		if (event.ctrlKey) {
+
+		if (Keymap.isModifier(event, "Mod")) {
 			const triggerName = ctrlMap.get(event.key);
 			if (triggerName) {
 				event.preventDefault();


### PR DESCRIPTION
Fixes #45 

Most keyboard shortcuts that use Ctrl on Windows/Linux are supposed to use Cmd on macOS. For example "paste" on macOS is `cmd+V` instead of `ctrl+V`, and "find" on macOS is `cmd+F` instead of `ctrl+F`.

This plugin currently does not account for this, and it uses incorrect shortcuts on macOS. Note that VSCode, which we are trying to emulate here, does use `cmd` for all of these shortcuts on macOS.

This PR is a very simple code change that fixes the issue, adding correct handling for the shortcuts modifier on macOS.