### PR TITLE
Change package-lock.json URLs to the default registry

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -1,0 +1,7 @@
+// Folder-specific settings
+//
+// For a full list of overridable settings, and general information on folder-specific settings,
+// see the documentation: https://zed.dev/docs/configuring-zed#settings-files
+{
+  "format_on_save": "off"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
 		},
 		"node_modules/@aashutoshrathi/word-wrap": {
 			"version": "1.2.6",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
+			"resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
 			"integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
 			"dev": true,
 			"peer": true,
@@ -35,14 +35,14 @@
 		},
 		"node_modules/@codemirror/state": {
 			"version": "6.2.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@codemirror/state/-/state-6.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.2.1.tgz",
 			"integrity": "sha512-RupHSZ8+OjNT38zU9fKH2sv+Dnlr8Eb8sl4NOnnqz95mCFTZUaiRP8Xv5MeeaG0px2b8Bnfe7YGwCV3nsBhbuw==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/@codemirror/view": {
 			"version": "6.19.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@codemirror/view/-/view-6.19.0.tgz",
+			"resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.19.0.tgz",
 			"integrity": "sha512-XqNIfW/3GaaF+T7Q1jBcRLCPm1NbrR2DBxrXacSt1FG+rNsdsNn3/azAfgpUoJ7yy4xgd8xTPa3AlL+y0lMizQ==",
 			"dev": true,
 			"peer": true,
@@ -54,7 +54,7 @@
 		},
 		"node_modules/@esbuild/android-arm": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/android-arm/-/android-arm-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.3.tgz",
 			"integrity": "sha512-1Mlz934GvbgdDmt26rTLmf03cAgLg5HyOgJN+ZGCeP3Q9ynYTNMn2/LQxIl7Uy+o4K6Rfi2OuLsr12JQQR8gNg==",
 			"cpu": [
 				"arm"
@@ -70,7 +70,7 @@
 		},
 		"node_modules/@esbuild/android-arm64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/android-arm64/-/android-arm64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.3.tgz",
 			"integrity": "sha512-XvJsYo3dO3Pi4kpalkyMvfQsjxPWHYjoX4MDiB/FUM4YMfWcXa5l4VCwFWVYI1+92yxqjuqrhNg0CZg3gSouyQ==",
 			"cpu": [
 				"arm64"
@@ -86,7 +86,7 @@
 		},
 		"node_modules/@esbuild/android-x64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/android-x64/-/android-x64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.3.tgz",
 			"integrity": "sha512-nuV2CmLS07Gqh5/GrZLuqkU9Bm6H6vcCspM+zjp9TdQlxJtIe+qqEXQChmfc7nWdyr/yz3h45Utk1tUn8Cz5+A==",
 			"cpu": [
 				"x64"
@@ -102,7 +102,7 @@
 		},
 		"node_modules/@esbuild/darwin-arm64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/darwin-arm64/-/darwin-arm64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.3.tgz",
 			"integrity": "sha512-01Hxaaat6m0Xp9AXGM8mjFtqqwDjzlMP0eQq9zll9U85ttVALGCGDuEvra5Feu/NbP5AEP1MaopPwzsTcUq1cw==",
 			"cpu": [
 				"arm64"
@@ -118,7 +118,7 @@
 		},
 		"node_modules/@esbuild/darwin-x64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/darwin-x64/-/darwin-x64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.3.tgz",
 			"integrity": "sha512-Eo2gq0Q/er2muf8Z83X21UFoB7EU6/m3GNKvrhACJkjVThd0uA+8RfKpfNhuMCl1bKRfBzKOk6xaYKQZ4lZqvA==",
 			"cpu": [
 				"x64"
@@ -134,7 +134,7 @@
 		},
 		"node_modules/@esbuild/freebsd-arm64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.3.tgz",
 			"integrity": "sha512-CN62ESxaquP61n1ZjQP/jZte8CE09M6kNn3baos2SeUfdVBkWN5n6vGp2iKyb/bm/x4JQzEvJgRHLGd5F5b81w==",
 			"cpu": [
 				"arm64"
@@ -150,7 +150,7 @@
 		},
 		"node_modules/@esbuild/freebsd-x64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/freebsd-x64/-/freebsd-x64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.3.tgz",
 			"integrity": "sha512-feq+K8TxIznZE+zhdVurF3WNJ/Sa35dQNYbaqM/wsCbWdzXr5lyq+AaTUSER2cUR+SXPnd/EY75EPRjf4s1SLg==",
 			"cpu": [
 				"x64"
@@ -166,7 +166,7 @@
 		},
 		"node_modules/@esbuild/linux-arm": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/linux-arm/-/linux-arm-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.3.tgz",
 			"integrity": "sha512-CLP3EgyNuPcg2cshbwkqYy5bbAgK+VhyfMU7oIYyn+x4Y67xb5C5ylxsNUjRmr8BX+MW3YhVNm6Lq6FKtRTWHQ==",
 			"cpu": [
 				"arm"
@@ -182,7 +182,7 @@
 		},
 		"node_modules/@esbuild/linux-arm64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/linux-arm64/-/linux-arm64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.3.tgz",
 			"integrity": "sha512-JHeZXD4auLYBnrKn6JYJ0o5nWJI9PhChA/Nt0G4MvLaMrvXuWnY93R3a7PiXeJQphpL1nYsaMcoV2QtuvRnF/g==",
 			"cpu": [
 				"arm64"
@@ -198,7 +198,7 @@
 		},
 		"node_modules/@esbuild/linux-ia32": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/linux-ia32/-/linux-ia32-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.3.tgz",
 			"integrity": "sha512-FyXlD2ZjZqTFh0sOQxFDiWG1uQUEOLbEh9gKN/7pFxck5Vw0qjWSDqbn6C10GAa1rXJpwsntHcmLqydY9ST9ZA==",
 			"cpu": [
 				"ia32"
@@ -214,7 +214,7 @@
 		},
 		"node_modules/@esbuild/linux-loong64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/linux-loong64/-/linux-loong64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.3.tgz",
 			"integrity": "sha512-OrDGMvDBI2g7s04J8dh8/I7eSO+/E7nMDT2Z5IruBfUO/RiigF1OF6xoH33Dn4W/OwAWSUf1s2nXamb28ZklTA==",
 			"cpu": [
 				"loong64"
@@ -230,7 +230,7 @@
 		},
 		"node_modules/@esbuild/linux-mips64el": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/linux-mips64el/-/linux-mips64el-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.3.tgz",
 			"integrity": "sha512-DcnUpXnVCJvmv0TzuLwKBC2nsQHle8EIiAJiJ+PipEVC16wHXaPEKP0EqN8WnBe0TPvMITOUlP2aiL5YMld+CQ==",
 			"cpu": [
 				"mips64el"
@@ -246,7 +246,7 @@
 		},
 		"node_modules/@esbuild/linux-ppc64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/linux-ppc64/-/linux-ppc64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.3.tgz",
 			"integrity": "sha512-BDYf/l1WVhWE+FHAW3FzZPtVlk9QsrwsxGzABmN4g8bTjmhazsId3h127pliDRRu5674k1Y2RWejbpN46N9ZhQ==",
 			"cpu": [
 				"ppc64"
@@ -262,7 +262,7 @@
 		},
 		"node_modules/@esbuild/linux-riscv64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/linux-riscv64/-/linux-riscv64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.3.tgz",
 			"integrity": "sha512-WViAxWYMRIi+prTJTyV1wnqd2mS2cPqJlN85oscVhXdb/ZTFJdrpaqm/uDsZPGKHtbg5TuRX/ymKdOSk41YZow==",
 			"cpu": [
 				"riscv64"
@@ -278,7 +278,7 @@
 		},
 		"node_modules/@esbuild/linux-s390x": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/linux-s390x/-/linux-s390x-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.3.tgz",
 			"integrity": "sha512-Iw8lkNHUC4oGP1O/KhumcVy77u2s6+KUjieUqzEU3XuWJqZ+AY7uVMrrCbAiwWTkpQHkr00BuXH5RpC6Sb/7Ug==",
 			"cpu": [
 				"s390x"
@@ -294,7 +294,7 @@
 		},
 		"node_modules/@esbuild/linux-x64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/linux-x64/-/linux-x64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.3.tgz",
 			"integrity": "sha512-0AGkWQMzeoeAtXQRNB3s4J1/T2XbigM2/Mn2yU1tQSmQRmHIZdkGbVq2A3aDdNslPyhb9/lH0S5GMTZ4xsjBqg==",
 			"cpu": [
 				"x64"
@@ -310,7 +310,7 @@
 		},
 		"node_modules/@esbuild/netbsd-x64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/netbsd-x64/-/netbsd-x64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.3.tgz",
 			"integrity": "sha512-4+rR/WHOxIVh53UIQIICryjdoKdHsFZFD4zLSonJ9RRw7bhKzVyXbnRPsWSfwybYqw9sB7ots/SYyufL1mBpEg==",
 			"cpu": [
 				"x64"
@@ -326,7 +326,7 @@
 		},
 		"node_modules/@esbuild/openbsd-x64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/openbsd-x64/-/openbsd-x64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.3.tgz",
 			"integrity": "sha512-cVpWnkx9IYg99EjGxa5Gc0XmqumtAwK3aoz7O4Dii2vko+qXbkHoujWA68cqXjhh6TsLaQelfDO4MVnyr+ODeA==",
 			"cpu": [
 				"x64"
@@ -342,7 +342,7 @@
 		},
 		"node_modules/@esbuild/sunos-x64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/sunos-x64/-/sunos-x64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.3.tgz",
 			"integrity": "sha512-RxmhKLbTCDAY2xOfrww6ieIZkZF+KBqG7S2Ako2SljKXRFi+0863PspK74QQ7JpmWwncChY25JTJSbVBYGQk2Q==",
 			"cpu": [
 				"x64"
@@ -358,7 +358,7 @@
 		},
 		"node_modules/@esbuild/win32-arm64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/win32-arm64/-/win32-arm64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.3.tgz",
 			"integrity": "sha512-0r36VeEJ4efwmofxVJRXDjVRP2jTmv877zc+i+Pc7MNsIr38NfsjkQj23AfF7l0WbB+RQ7VUb+LDiqC/KY/M/A==",
 			"cpu": [
 				"arm64"
@@ -374,7 +374,7 @@
 		},
 		"node_modules/@esbuild/win32-ia32": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/win32-ia32/-/win32-ia32-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.3.tgz",
 			"integrity": "sha512-wgO6rc7uGStH22nur4aLFcq7Wh86bE9cOFmfTr/yxN3BXvDEdCSXyKkO+U5JIt53eTOgC47v9k/C1bITWL/Teg==",
 			"cpu": [
 				"ia32"
@@ -390,7 +390,7 @@
 		},
 		"node_modules/@esbuild/win32-x64": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@esbuild/win32-x64/-/win32-x64-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.3.tgz",
 			"integrity": "sha512-FdVl64OIuiKjgXBjwZaJLKp0eaEckifbhn10dXWhysMJkWblg3OEEGKSIyhiD5RSgAya8WzP3DNkngtIg3Nt7g==",
 			"cpu": [
 				"x64"
@@ -406,7 +406,7 @@
 		},
 		"node_modules/@eslint-community/eslint-utils": {
 			"version": "4.4.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
 			"integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
 			"dev": true,
 			"peer": true,
@@ -422,7 +422,7 @@
 		},
 		"node_modules/@eslint-community/regexpp": {
 			"version": "4.8.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@eslint-community/regexpp/-/regexpp-4.8.1.tgz",
+			"resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.8.1.tgz",
 			"integrity": "sha512-PWiOzLIUAjN/w5K17PoF4n6sKBw0gqLHPhywmYHP4t1VFQQVYeb1yWsJwnMVEMl3tUHME7X/SJPZLmtG7XBDxQ==",
 			"dev": true,
 			"peer": true,
@@ -432,7 +432,7 @@
 		},
 		"node_modules/@eslint/eslintrc": {
 			"version": "2.1.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.2.tgz",
 			"integrity": "sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==",
 			"dev": true,
 			"peer": true,
@@ -456,7 +456,7 @@
 		},
 		"node_modules/@eslint/js": {
 			"version": "8.49.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@eslint/js/-/js-8.49.0.tgz",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.49.0.tgz",
 			"integrity": "sha512-1S8uAY/MTJqVx0SC4epBq+N2yhuwtNwLbJYNZyhL2pO1ZVKn5HFXav5T41Ryzy9K9V7ZId2JB2oy/W4aCd9/2w==",
 			"dev": true,
 			"peer": true,
@@ -466,7 +466,7 @@
 		},
 		"node_modules/@humanwhocodes/config-array": {
 			"version": "0.11.11",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
 			"integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
 			"dev": true,
 			"peer": true,
@@ -481,7 +481,7 @@
 		},
 		"node_modules/@humanwhocodes/module-importer": {
 			"version": "1.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
 			"integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
 			"dev": true,
 			"peer": true,
@@ -495,14 +495,14 @@
 		},
 		"node_modules/@humanwhocodes/object-schema": {
 			"version": "1.2.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
 			"integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
+			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.3.tgz",
 			"integrity": "sha512-HLhSWOLRi875zjjMG/r+Nv0oCW8umGb0BgEhyX3dDX3egwZtB8PqLnjz3yedt8R5StBrzcg4aBpnh8UA9D1BoQ==",
 			"dev": true,
 			"dependencies": {
@@ -516,7 +516,7 @@
 		},
 		"node_modules/@jridgewell/resolve-uri": {
 			"version": "3.1.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
 			"integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
 			"dev": true,
 			"engines": {
@@ -525,7 +525,7 @@
 		},
 		"node_modules/@jridgewell/set-array": {
 			"version": "1.1.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@jridgewell/set-array/-/set-array-1.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.1.2.tgz",
 			"integrity": "sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==",
 			"dev": true,
 			"engines": {
@@ -534,7 +534,7 @@
 		},
 		"node_modules/@jridgewell/source-map": {
 			"version": "0.3.5",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@jridgewell/source-map/-/source-map-0.3.5.tgz",
+			"resolved": "https://registry.npmjs.org/@jridgewell/source-map/-/source-map-0.3.5.tgz",
 			"integrity": "sha512-UTYAUj/wviwdsMfzoSJspJxbkH5o1snzwX0//0ENX1u/55kkZZkcTZP6u9bwKGkv+dkk9at4m1Cpt0uY80kcpQ==",
 			"dev": true,
 			"dependencies": {
@@ -544,13 +544,13 @@
 		},
 		"node_modules/@jridgewell/sourcemap-codec": {
 			"version": "1.4.15",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
+			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
 			"integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
 			"dev": true
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.19",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
+			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
 			"integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
 			"dev": true,
 			"dependencies": {
@@ -560,7 +560,7 @@
 		},
 		"node_modules/@nodelib/fs.scandir": {
 			"version": "2.1.5",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
 			"integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
 			"dev": true,
 			"dependencies": {
@@ -573,7 +573,7 @@
 		},
 		"node_modules/@nodelib/fs.stat": {
 			"version": "2.0.5",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
 			"integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
 			"dev": true,
 			"engines": {
@@ -582,7 +582,7 @@
 		},
 		"node_modules/@nodelib/fs.walk": {
 			"version": "1.2.8",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
 			"integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
 			"dev": true,
 			"dependencies": {
@@ -595,7 +595,7 @@
 		},
 		"node_modules/@types/codemirror": {
 			"version": "5.60.8",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@types/codemirror/-/codemirror-5.60.8.tgz",
+			"resolved": "https://registry.npmjs.org/@types/codemirror/-/codemirror-5.60.8.tgz",
 			"integrity": "sha512-VjFgDF/eB+Aklcy15TtOTLQeMjTo07k7KAjql8OK5Dirr7a6sJY4T1uVBDuTVG9VEmn1uUsohOpYnVfgC6/jyw==",
 			"dev": true,
 			"dependencies": {
@@ -604,25 +604,25 @@
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@types/estree/-/estree-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.1.tgz",
 			"integrity": "sha512-LG4opVs2ANWZ1TJoKc937iMmNstM/d0ae1vNbnBvBhqCSezgVUOzcLCqbI5elV8Vy6WKwKjaqR+zO9VKirBBCA==",
 			"dev": true
 		},
 		"node_modules/@types/json-schema": {
 			"version": "7.0.12",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@types/json-schema/-/json-schema-7.0.12.tgz",
+			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.12.tgz",
 			"integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
 			"dev": true
 		},
 		"node_modules/@types/node": {
 			"version": "16.18.50",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@types/node/-/node-16.18.50.tgz",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.50.tgz",
 			"integrity": "sha512-OiDU5xRgYTJ203v4cprTs0RwOCd5c5Zjv+K5P8KSqfiCsB1W3LcamTUMcnQarpq5kOYbhHfSOgIEJvdPyb5xyw==",
 			"dev": true
 		},
 		"node_modules/@types/tern": {
 			"version": "0.23.5",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@types/tern/-/tern-0.23.5.tgz",
+			"resolved": "https://registry.npmjs.org/@types/tern/-/tern-0.23.5.tgz",
 			"integrity": "sha512-POau56wDk3TQ0mQ0qG7XDzv96U5whSENZ9lC0htDvEH+9YUREo+J2U+apWcVRgR2UydEE70JXZo44goG+akTNQ==",
 			"dev": true,
 			"dependencies": {
@@ -631,7 +631,7 @@
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "5.29.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.29.0.tgz",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.29.0.tgz",
 			"integrity": "sha512-kgTsISt9pM53yRFQmLZ4npj99yGl3x3Pl7z4eA66OuTzAGC4bQB5H5fuLwPnqTKU3yyrrg4MIhjF17UYnL4c0w==",
 			"dev": true,
 			"dependencies": {
@@ -664,7 +664,7 @@
 		},
 		"node_modules/@typescript-eslint/parser": {
 			"version": "5.29.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@typescript-eslint/parser/-/parser-5.29.0.tgz",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.29.0.tgz",
 			"integrity": "sha512-ruKWTv+x0OOxbzIw9nW5oWlUopvP/IQDjB5ZqmTglLIoDTctLlAJpAQFpNPJP/ZI7hTT9sARBosEfaKbcFuECw==",
 			"dev": true,
 			"dependencies": {
@@ -691,7 +691,7 @@
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
 			"version": "5.29.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-5.29.0.tgz",
 			"integrity": "sha512-etbXUT0FygFi2ihcxDZjz21LtC+Eps9V2xVx09zFoN44RRHPrkMflidGMI+2dUs821zR1tDS6Oc9IXxIjOUZwA==",
 			"dev": true,
 			"dependencies": {
@@ -708,7 +708,7 @@
 		},
 		"node_modules/@typescript-eslint/type-utils": {
 			"version": "5.29.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@typescript-eslint/type-utils/-/type-utils-5.29.0.tgz",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-5.29.0.tgz",
 			"integrity": "sha512-JK6bAaaiJozbox3K220VRfCzLa9n0ib/J+FHIwnaV3Enw/TO267qe0pM1b1QrrEuy6xun374XEAsRlA86JJnyg==",
 			"dev": true,
 			"dependencies": {
@@ -734,7 +734,7 @@
 		},
 		"node_modules/@typescript-eslint/types": {
 			"version": "5.29.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@typescript-eslint/types/-/types-5.29.0.tgz",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-5.29.0.tgz",
 			"integrity": "sha512-X99VbqvAXOMdVyfFmksMy3u8p8yoRGITgU1joBJPzeYa0rhdf5ok9S56/itRoUSh99fiDoMtarSIJXo7H/SnOg==",
 			"dev": true,
 			"engines": {
@@ -747,7 +747,7 @@
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
 			"version": "5.29.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-5.29.0.tgz",
 			"integrity": "sha512-mQvSUJ/JjGBdvo+1LwC+GY2XmSYjK1nAaVw2emp/E61wEVYEyibRHCqm1I1vEKbXCpUKuW4G7u9ZCaZhJbLoNQ==",
 			"dev": true,
 			"dependencies": {
@@ -774,7 +774,7 @@
 		},
 		"node_modules/@typescript-eslint/utils": {
 			"version": "5.29.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@typescript-eslint/utils/-/utils-5.29.0.tgz",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-5.29.0.tgz",
 			"integrity": "sha512-3Eos6uP1nyLOBayc/VUdKZikV90HahXE5Dx9L5YlSd/7ylQPXhLk1BYb29SDgnBnTp+jmSZUU0QxUiyHgW4p7A==",
 			"dev": true,
 			"dependencies": {
@@ -798,7 +798,7 @@
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
 			"version": "5.29.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-5.29.0.tgz",
 			"integrity": "sha512-Hpb/mCWsjILvikMQoZIE3voc9wtQcS0A9FUw3h8bhr9UxBdtI/tw1ZDZUOXHXLOVMedKCH5NxyzATwnU78bWCQ==",
 			"dev": true,
 			"dependencies": {
@@ -815,7 +815,7 @@
 		},
 		"node_modules/acorn": {
 			"version": "8.10.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/acorn/-/acorn-8.10.0.tgz",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
 			"integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
 			"dev": true,
 			"bin": {
@@ -827,7 +827,7 @@
 		},
 		"node_modules/acorn-jsx": {
 			"version": "5.3.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
+			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
 			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
 			"peer": true,
@@ -837,7 +837,7 @@
 		},
 		"node_modules/ajv": {
 			"version": "6.12.6",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/ajv/-/ajv-6.12.6.tgz",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
 			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"peer": true,
@@ -854,7 +854,7 @@
 		},
 		"node_modules/ansi-regex": {
 			"version": "5.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/ansi-regex/-/ansi-regex-5.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true,
 			"peer": true,
@@ -864,7 +864,7 @@
 		},
 		"node_modules/ansi-styles": {
 			"version": "4.3.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/ansi-styles/-/ansi-styles-4.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
 			"integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
 			"dev": true,
 			"peer": true,
@@ -880,14 +880,14 @@
 		},
 		"node_modules/argparse": {
 			"version": "2.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/argparse/-/argparse-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
 			"integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/array-union": {
 			"version": "2.1.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/array-union/-/array-union-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
 			"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
 			"dev": true,
 			"engines": {
@@ -896,14 +896,14 @@
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/balanced-match/-/balanced-match-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
 			"integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/brace-expansion": {
 			"version": "1.1.11",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/brace-expansion/-/brace-expansion-1.1.11.tgz",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
 			"integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
 			"dev": true,
 			"peer": true,
@@ -914,7 +914,7 @@
 		},
 		"node_modules/braces": {
 			"version": "3.0.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/braces/-/braces-3.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
 			"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
 			"dev": true,
 			"dependencies": {
@@ -926,13 +926,13 @@
 		},
 		"node_modules/buffer-from": {
 			"version": "1.1.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/buffer-from/-/buffer-from-1.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
 			"integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
 			"dev": true
 		},
 		"node_modules/builtin-modules": {
 			"version": "3.3.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/builtin-modules/-/builtin-modules-3.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.3.0.tgz",
 			"integrity": "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==",
 			"dev": true,
 			"engines": {
@@ -944,7 +944,7 @@
 		},
 		"node_modules/callsites": {
 			"version": "3.1.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/callsites/-/callsites-3.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
 			"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
 			"dev": true,
 			"peer": true,
@@ -954,7 +954,7 @@
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/chalk/-/chalk-4.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
 			"integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
 			"dev": true,
 			"peer": true,
@@ -971,7 +971,7 @@
 		},
 		"node_modules/color-convert": {
 			"version": "2.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/color-convert/-/color-convert-2.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
 			"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
 			"dev": true,
 			"peer": true,
@@ -984,27 +984,27 @@
 		},
 		"node_modules/color-name": {
 			"version": "1.1.4",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/color-name/-/color-name-1.1.4.tgz",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/commander": {
 			"version": "2.20.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/commander/-/commander-2.20.3.tgz",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
 			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
 			"dev": true
 		},
 		"node_modules/concat-map": {
 			"version": "0.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/concat-map/-/concat-map-0.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
 			"integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/cross-spawn/-/cross-spawn-7.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
 			"integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
 			"dev": true,
 			"peer": true,
@@ -1019,7 +1019,7 @@
 		},
 		"node_modules/debug": {
 			"version": "4.3.4",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/debug/-/debug-4.3.4.tgz",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
 			"integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
 			"dev": true,
 			"dependencies": {
@@ -1036,14 +1036,14 @@
 		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/deep-is/-/deep-is-0.1.4.tgz",
+			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
 			"integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/dir-glob": {
 			"version": "3.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/dir-glob/-/dir-glob-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
 			"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
 			"dev": true,
 			"dependencies": {
@@ -1055,7 +1055,7 @@
 		},
 		"node_modules/doctrine": {
 			"version": "3.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/doctrine/-/doctrine-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
 			"integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
 			"dev": true,
 			"peer": true,
@@ -1068,7 +1068,7 @@
 		},
 		"node_modules/esbuild": {
 			"version": "0.17.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/esbuild/-/esbuild-0.17.3.tgz",
+			"resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.3.tgz",
 			"integrity": "sha512-9n3AsBRe6sIyOc6kmoXg2ypCLgf3eZSraWFRpnkto+svt8cZNuKTkb1bhQcitBcvIqjNiK7K0J3KPmwGSfkA8g==",
 			"dev": true,
 			"hasInstallScript": true,
@@ -1105,7 +1105,7 @@
 		},
 		"node_modules/escape-string-regexp": {
 			"version": "4.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
 			"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
 			"dev": true,
 			"peer": true,
@@ -1118,7 +1118,7 @@
 		},
 		"node_modules/eslint": {
 			"version": "8.49.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/eslint/-/eslint-8.49.0.tgz",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.49.0.tgz",
 			"integrity": "sha512-jw03ENfm6VJI0jA9U+8H5zfl5b+FvuU3YYvZRdZHOlU2ggJkxrlkJH4HcDrZpj6YwD8kuYqvQM8LyesoazrSOQ==",
 			"dev": true,
 			"peer": true,
@@ -1173,7 +1173,7 @@
 		},
 		"node_modules/eslint-scope": {
 			"version": "5.1.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/eslint-scope/-/eslint-scope-5.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
 			"integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
 			"dev": true,
 			"dependencies": {
@@ -1186,7 +1186,7 @@
 		},
 		"node_modules/eslint-utils": {
 			"version": "3.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/eslint-utils/-/eslint-utils-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-3.0.0.tgz",
 			"integrity": "sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==",
 			"dev": true,
 			"dependencies": {
@@ -1204,7 +1204,7 @@
 		},
 		"node_modules/eslint-utils/node_modules/eslint-visitor-keys": {
 			"version": "2.1.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz",
 			"integrity": "sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==",
 			"dev": true,
 			"engines": {
@@ -1213,7 +1213,7 @@
 		},
 		"node_modules/eslint-visitor-keys": {
 			"version": "3.4.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
+			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
 			"integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
 			"dev": true,
 			"engines": {
@@ -1225,7 +1225,7 @@
 		},
 		"node_modules/eslint/node_modules/eslint-scope": {
 			"version": "7.2.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/eslint-scope/-/eslint-scope-7.2.2.tgz",
+			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
 			"integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
 			"dev": true,
 			"peer": true,
@@ -1242,7 +1242,7 @@
 		},
 		"node_modules/eslint/node_modules/estraverse": {
 			"version": "5.3.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/estraverse/-/estraverse-5.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
 			"peer": true,
@@ -1252,7 +1252,7 @@
 		},
 		"node_modules/espree": {
 			"version": "9.6.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/espree/-/espree-9.6.1.tgz",
+			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
 			"integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
 			"dev": true,
 			"peer": true,
@@ -1270,7 +1270,7 @@
 		},
 		"node_modules/esquery": {
 			"version": "1.5.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/esquery/-/esquery-1.5.0.tgz",
+			"resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
 			"integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
 			"dev": true,
 			"peer": true,
@@ -1283,7 +1283,7 @@
 		},
 		"node_modules/esquery/node_modules/estraverse": {
 			"version": "5.3.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/estraverse/-/estraverse-5.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
 			"peer": true,
@@ -1293,7 +1293,7 @@
 		},
 		"node_modules/esrecurse": {
 			"version": "4.3.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/esrecurse/-/esrecurse-4.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
 			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
 			"dependencies": {
@@ -1305,7 +1305,7 @@
 		},
 		"node_modules/esrecurse/node_modules/estraverse": {
 			"version": "5.3.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/estraverse/-/estraverse-5.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
 			"integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
 			"dev": true,
 			"engines": {
@@ -1314,7 +1314,7 @@
 		},
 		"node_modules/estraverse": {
 			"version": "4.3.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/estraverse/-/estraverse-4.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
 			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
 			"dev": true,
 			"engines": {
@@ -1323,7 +1323,7 @@
 		},
 		"node_modules/esutils": {
 			"version": "2.0.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/esutils/-/esutils-2.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
 			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
 			"dev": true,
 			"peer": true,
@@ -1333,14 +1333,14 @@
 		},
 		"node_modules/fast-deep-equal": {
 			"version": "3.1.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
 			"integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/fast-glob": {
 			"version": "3.3.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/fast-glob/-/fast-glob-3.3.1.tgz",
+			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
 			"integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
 			"dev": true,
 			"dependencies": {
@@ -1356,7 +1356,7 @@
 		},
 		"node_modules/fast-glob/node_modules/glob-parent": {
 			"version": "5.1.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/glob-parent/-/glob-parent-5.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
 			"integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
 			"dev": true,
 			"dependencies": {
@@ -1368,21 +1368,21 @@
 		},
 		"node_modules/fast-json-stable-stringify": {
 			"version": "2.1.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
 			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/fast-levenshtein": {
 			"version": "2.0.6",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
 			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/fastq": {
 			"version": "1.15.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/fastq/-/fastq-1.15.0.tgz",
+			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
 			"integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
 			"dev": true,
 			"dependencies": {
@@ -1391,7 +1391,7 @@
 		},
 		"node_modules/file-entry-cache": {
 			"version": "6.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
 			"integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
 			"dev": true,
 			"peer": true,
@@ -1404,7 +1404,7 @@
 		},
 		"node_modules/fill-range": {
 			"version": "7.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/fill-range/-/fill-range-7.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
 			"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
 			"dev": true,
 			"dependencies": {
@@ -1416,7 +1416,7 @@
 		},
 		"node_modules/find-up": {
 			"version": "5.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/find-up/-/find-up-5.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
 			"integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
 			"dev": true,
 			"peer": true,
@@ -1433,7 +1433,7 @@
 		},
 		"node_modules/flat-cache": {
 			"version": "3.1.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/flat-cache/-/flat-cache-3.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.0.tgz",
 			"integrity": "sha512-OHx4Qwrrt0E4jEIcI5/Xb+f+QmJYNj2rrK8wiIdQOIrB9WrrJL8cjZvXdXuBTkkEwEqLycb5BeZDV1o2i9bTew==",
 			"dev": true,
 			"peer": true,
@@ -1448,27 +1448,27 @@
 		},
 		"node_modules/flatted": {
 			"version": "3.2.7",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/flatted/-/flatted-3.2.7.tgz",
+			"resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.7.tgz",
 			"integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/fs.realpath/-/fs.realpath-1.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
 			"integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/functional-red-black-tree": {
 			"version": "1.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
 			"integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
 			"dev": true
 		},
 		"node_modules/glob": {
 			"version": "7.2.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/glob/-/glob-7.2.3.tgz",
+			"resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
 			"integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
 			"dev": true,
 			"peer": true,
@@ -1489,7 +1489,7 @@
 		},
 		"node_modules/glob-parent": {
 			"version": "6.0.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/glob-parent/-/glob-parent-6.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
 			"integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
 			"dev": true,
 			"peer": true,
@@ -1502,7 +1502,7 @@
 		},
 		"node_modules/globals": {
 			"version": "13.21.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/globals/-/globals-13.21.0.tgz",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.21.0.tgz",
 			"integrity": "sha512-ybyme3s4yy/t/3s35bewwXKOf7cvzfreG2lH0lZl0JB7I4GxRP2ghxOK/Nb9EkRXdbBXZLfq/p/0W2JUONB/Gg==",
 			"dev": true,
 			"peer": true,
@@ -1518,7 +1518,7 @@
 		},
 		"node_modules/globby": {
 			"version": "11.1.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/globby/-/globby-11.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
 			"integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
 			"dev": true,
 			"dependencies": {
@@ -1538,14 +1538,14 @@
 		},
 		"node_modules/graphemer": {
 			"version": "1.4.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/graphemer/-/graphemer-1.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
 			"integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/has-flag/-/has-flag-4.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
 			"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
 			"dev": true,
 			"peer": true,
@@ -1555,7 +1555,7 @@
 		},
 		"node_modules/ignore": {
 			"version": "5.2.4",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/ignore/-/ignore-5.2.4.tgz",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
 			"integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
 			"dev": true,
 			"engines": {
@@ -1564,7 +1564,7 @@
 		},
 		"node_modules/import-fresh": {
 			"version": "3.3.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/import-fresh/-/import-fresh-3.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
 			"integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
 			"dev": true,
 			"peer": true,
@@ -1581,7 +1581,7 @@
 		},
 		"node_modules/imurmurhash": {
 			"version": "0.1.4",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/imurmurhash/-/imurmurhash-0.1.4.tgz",
+			"resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
 			"integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
 			"dev": true,
 			"peer": true,
@@ -1591,7 +1591,7 @@
 		},
 		"node_modules/inflight": {
 			"version": "1.0.6",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/inflight/-/inflight-1.0.6.tgz",
+			"resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
 			"integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
 			"dev": true,
 			"peer": true,
@@ -1602,14 +1602,14 @@
 		},
 		"node_modules/inherits": {
 			"version": "2.0.4",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/inherits/-/inherits-2.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
 			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/is-extglob/-/is-extglob-2.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
 			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
 			"dev": true,
 			"engines": {
@@ -1618,7 +1618,7 @@
 		},
 		"node_modules/is-glob": {
 			"version": "4.0.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/is-glob/-/is-glob-4.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
 			"integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
 			"dev": true,
 			"dependencies": {
@@ -1630,7 +1630,7 @@
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/is-number/-/is-number-7.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
 			"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
 			"dev": true,
 			"engines": {
@@ -1639,7 +1639,7 @@
 		},
 		"node_modules/is-path-inside": {
 			"version": "3.0.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/is-path-inside/-/is-path-inside-3.0.3.tgz",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
 			"integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
 			"dev": true,
 			"peer": true,
@@ -1649,14 +1649,14 @@
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/isexe/-/isexe-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
 			"integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/js-yaml": {
 			"version": "4.1.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/js-yaml/-/js-yaml-4.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
 			"integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
 			"dev": true,
 			"peer": true,
@@ -1669,28 +1669,28 @@
 		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/json-buffer/-/json-buffer-3.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
 			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/json-schema-traverse": {
 			"version": "0.4.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
 			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
 			"integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/keyv": {
 			"version": "4.5.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/keyv/-/keyv-4.5.3.tgz",
+			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.3.tgz",
 			"integrity": "sha512-QCiSav9WaX1PgETJ+SpNnx2PRRapJ/oRSXM4VO5OGYGSjrxbKPVFVhB3l2OCbLCk329N8qyAtsJjSjvVBWzEug==",
 			"dev": true,
 			"peer": true,
@@ -1700,7 +1700,7 @@
 		},
 		"node_modules/levn": {
 			"version": "0.4.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/levn/-/levn-0.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
 			"integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
 			"dev": true,
 			"peer": true,
@@ -1714,7 +1714,7 @@
 		},
 		"node_modules/locate-path": {
 			"version": "6.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/locate-path/-/locate-path-6.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
 			"integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
 			"dev": true,
 			"peer": true,
@@ -1730,14 +1730,14 @@
 		},
 		"node_modules/lodash.merge": {
 			"version": "4.6.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/lodash.merge/-/lodash.merge-4.6.2.tgz",
+			"resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
 			"integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/lru-cache": {
 			"version": "6.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/lru-cache/-/lru-cache-6.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
 			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
 			"dev": true,
 			"dependencies": {
@@ -1749,7 +1749,7 @@
 		},
 		"node_modules/merge2": {
 			"version": "1.4.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/merge2/-/merge2-1.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
 			"integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
 			"dev": true,
 			"engines": {
@@ -1758,7 +1758,7 @@
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.5",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/micromatch/-/micromatch-4.0.5.tgz",
+			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
 			"integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
 			"dev": true,
 			"dependencies": {
@@ -1771,7 +1771,7 @@
 		},
 		"node_modules/minimatch": {
 			"version": "3.1.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/minimatch/-/minimatch-3.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
 			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"peer": true,
@@ -1784,7 +1784,7 @@
 		},
 		"node_modules/moment": {
 			"version": "2.29.4",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/moment/-/moment-2.29.4.tgz",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
 			"integrity": "sha512-5LC9SOxjSc2HF6vO2CyuTDNivEdoz2IvyJJGj6X8DJ0eFyfszE0QiEd+iXmBvUP3WHxSjFH/vIsA0EN00cgr8w==",
 			"dev": true,
 			"engines": {
@@ -1793,25 +1793,25 @@
 		},
 		"node_modules/monaco-editor": {
 			"version": "0.43.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/monaco-editor/-/monaco-editor-0.43.0.tgz",
+			"resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.43.0.tgz",
 			"integrity": "sha512-cnoqwQi/9fml2Szamv1XbSJieGJ1Dc8tENVMD26Kcfl7xGQWp7OBKMjlwKVGYFJ3/AXJjSOGvcqK7Ry/j9BM1Q=="
 		},
 		"node_modules/ms": {
 			"version": "2.1.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/ms/-/ms-2.1.2.tgz",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
 			"dev": true
 		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/natural-compare/-/natural-compare-1.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
 			"integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/obsidian": {
 			"version": "1.4.11",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/obsidian/-/obsidian-1.4.11.tgz",
+			"resolved": "https://registry.npmjs.org/obsidian/-/obsidian-1.4.11.tgz",
 			"integrity": "sha512-BCVYTvaXxElJMl6MMbDdY/CGK+aq18SdtDY/7vH8v6BxCBQ6KF4kKxL0vG9UZ0o5qh139KpUoJHNm+6O5dllKA==",
 			"dev": true,
 			"dependencies": {
@@ -1825,7 +1825,7 @@
 		},
 		"node_modules/once": {
 			"version": "1.4.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/once/-/once-1.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
 			"dev": true,
 			"peer": true,
@@ -1835,7 +1835,7 @@
 		},
 		"node_modules/optionator": {
 			"version": "0.9.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/optionator/-/optionator-0.9.3.tgz",
+			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
 			"integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
 			"dev": true,
 			"peer": true,
@@ -1853,7 +1853,7 @@
 		},
 		"node_modules/p-limit": {
 			"version": "3.1.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/p-limit/-/p-limit-3.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
 			"integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
 			"dev": true,
 			"peer": true,
@@ -1869,7 +1869,7 @@
 		},
 		"node_modules/p-locate": {
 			"version": "5.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/p-locate/-/p-locate-5.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
 			"integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
 			"dev": true,
 			"peer": true,
@@ -1885,7 +1885,7 @@
 		},
 		"node_modules/parent-module": {
 			"version": "1.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/parent-module/-/parent-module-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
 			"dev": true,
 			"peer": true,
@@ -1898,7 +1898,7 @@
 		},
 		"node_modules/path-exists": {
 			"version": "4.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/path-exists/-/path-exists-4.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
 			"integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
 			"dev": true,
 			"peer": true,
@@ -1908,7 +1908,7 @@
 		},
 		"node_modules/path-is-absolute": {
 			"version": "1.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
 			"integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
 			"dev": true,
 			"peer": true,
@@ -1918,7 +1918,7 @@
 		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/path-key/-/path-key-3.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
 			"integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
 			"dev": true,
 			"peer": true,
@@ -1928,7 +1928,7 @@
 		},
 		"node_modules/path-type": {
 			"version": "4.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/path-type/-/path-type-4.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
 			"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
 			"dev": true,
 			"engines": {
@@ -1937,7 +1937,7 @@
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/picomatch/-/picomatch-2.3.1.tgz",
+			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
 			"integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
 			"dev": true,
 			"engines": {
@@ -1949,7 +1949,7 @@
 		},
 		"node_modules/prelude-ls": {
 			"version": "1.2.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/prelude-ls/-/prelude-ls-1.2.1.tgz",
+			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
 			"integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
 			"dev": true,
 			"peer": true,
@@ -1959,7 +1959,7 @@
 		},
 		"node_modules/punycode": {
 			"version": "2.3.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/punycode/-/punycode-2.3.0.tgz",
+			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
 			"integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
 			"dev": true,
 			"peer": true,
@@ -1969,7 +1969,7 @@
 		},
 		"node_modules/queue-microtask": {
 			"version": "1.2.3",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/queue-microtask/-/queue-microtask-1.2.3.tgz",
+			"resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
 			"integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
 			"dev": true,
 			"funding": [
@@ -1989,7 +1989,7 @@
 		},
 		"node_modules/regexpp": {
 			"version": "3.2.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/regexpp/-/regexpp-3.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
 			"integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
 			"dev": true,
 			"engines": {
@@ -2001,7 +2001,7 @@
 		},
 		"node_modules/resolve-from": {
 			"version": "4.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/resolve-from/-/resolve-from-4.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
 			"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
 			"dev": true,
 			"peer": true,
@@ -2011,7 +2011,7 @@
 		},
 		"node_modules/reusify": {
 			"version": "1.0.4",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/reusify/-/reusify-1.0.4.tgz",
+			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
 			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
 			"dev": true,
 			"engines": {
@@ -2021,7 +2021,7 @@
 		},
 		"node_modules/rimraf": {
 			"version": "3.0.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/rimraf/-/rimraf-3.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
 			"integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
 			"dev": true,
 			"peer": true,
@@ -2037,7 +2037,7 @@
 		},
 		"node_modules/run-parallel": {
 			"version": "1.2.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/run-parallel/-/run-parallel-1.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
 			"integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
 			"dev": true,
 			"funding": [
@@ -2060,7 +2060,7 @@
 		},
 		"node_modules/semver": {
 			"version": "7.5.4",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/semver/-/semver-7.5.4.tgz",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
 			"integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
 			"dev": true,
 			"dependencies": {
@@ -2075,7 +2075,7 @@
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/shebang-command/-/shebang-command-2.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
 			"integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
 			"dev": true,
 			"peer": true,
@@ -2088,7 +2088,7 @@
 		},
 		"node_modules/shebang-regex": {
 			"version": "3.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/shebang-regex/-/shebang-regex-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
 			"integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
 			"dev": true,
 			"peer": true,
@@ -2098,7 +2098,7 @@
 		},
 		"node_modules/slash": {
 			"version": "3.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/slash/-/slash-3.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
 			"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
 			"dev": true,
 			"engines": {
@@ -2107,7 +2107,7 @@
 		},
 		"node_modules/source-map": {
 			"version": "0.6.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/source-map/-/source-map-0.6.1.tgz",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 			"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
 			"dev": true,
 			"engines": {
@@ -2116,7 +2116,7 @@
 		},
 		"node_modules/source-map-support": {
 			"version": "0.5.21",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/source-map-support/-/source-map-support-0.5.21.tgz",
+			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
 			"integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
 			"dev": true,
 			"dependencies": {
@@ -2126,7 +2126,7 @@
 		},
 		"node_modules/strip-ansi": {
 			"version": "6.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/strip-ansi/-/strip-ansi-6.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
 			"integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
 			"dev": true,
 			"peer": true,
@@ -2139,7 +2139,7 @@
 		},
 		"node_modules/strip-json-comments": {
 			"version": "3.1.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
 			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
 			"dev": true,
 			"peer": true,
@@ -2152,14 +2152,14 @@
 		},
 		"node_modules/style-mod": {
 			"version": "4.1.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/style-mod/-/style-mod-4.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.0.tgz",
 			"integrity": "sha512-Ca5ib8HrFn+f+0n4N4ScTIA9iTOQ7MaGS1ylHcoVqW9J7w2w8PzN6g9gKmTYgGEBH8e120+RCmhpje6jC5uGWA==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/supports-color/-/supports-color-7.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
 			"integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
 			"dev": true,
 			"peer": true,
@@ -2172,7 +2172,7 @@
 		},
 		"node_modules/terser": {
 			"version": "5.20.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/terser/-/terser-5.20.0.tgz",
+			"resolved": "https://registry.npmjs.org/terser/-/terser-5.20.0.tgz",
 			"integrity": "sha512-e56ETryaQDyebBwJIWYB2TT6f2EZ0fL0sW/JRXNMN26zZdKi2u/E/5my5lG6jNxym6qsrVXfFRmOdV42zlAgLQ==",
 			"dev": true,
 			"dependencies": {
@@ -2190,14 +2190,14 @@
 		},
 		"node_modules/text-table": {
 			"version": "0.2.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/text-table/-/text-table-0.2.0.tgz",
+			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/to-regex-range/-/to-regex-range-5.0.1.tgz",
+			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 			"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
 			"dev": true,
 			"dependencies": {
@@ -2209,13 +2209,13 @@
 		},
 		"node_modules/tslib": {
 			"version": "2.4.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/tslib/-/tslib-2.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.0.tgz",
 			"integrity": "sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==",
 			"dev": true
 		},
 		"node_modules/tsutils": {
 			"version": "3.21.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/tsutils/-/tsutils-3.21.0.tgz",
+			"resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.21.0.tgz",
 			"integrity": "sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==",
 			"dev": true,
 			"dependencies": {
@@ -2230,13 +2230,13 @@
 		},
 		"node_modules/tsutils/node_modules/tslib": {
 			"version": "1.14.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/tslib/-/tslib-1.14.1.tgz",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"dev": true
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/type-check/-/type-check-0.4.0.tgz",
+			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
 			"integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
 			"dev": true,
 			"peer": true,
@@ -2249,7 +2249,7 @@
 		},
 		"node_modules/type-fest": {
 			"version": "0.20.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/type-fest/-/type-fest-0.20.2.tgz",
+			"resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
 			"integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
 			"dev": true,
 			"peer": true,
@@ -2262,7 +2262,7 @@
 		},
 		"node_modules/typescript": {
 			"version": "4.7.4",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/typescript/-/typescript-4.7.4.tgz",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
 			"integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
 			"dev": true,
 			"bin": {
@@ -2275,7 +2275,7 @@
 		},
 		"node_modules/uri-js": {
 			"version": "4.4.1",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/uri-js/-/uri-js-4.4.1.tgz",
+			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
 			"integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
 			"dev": true,
 			"peer": true,
@@ -2285,14 +2285,14 @@
 		},
 		"node_modules/w3c-keyname": {
 			"version": "2.2.8",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+			"resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
 			"integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/which/-/which-2.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
 			"integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
 			"dev": true,
 			"peer": true,
@@ -2308,20 +2308,20 @@
 		},
 		"node_modules/wrappy": {
 			"version": "1.0.2",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/wrappy/-/wrappy-1.0.2.tgz",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
 			"dev": true,
 			"peer": true
 		},
 		"node_modules/yallist": {
 			"version": "4.0.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/yallist/-/yallist-4.0.0.tgz",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"dev": true
 		},
 		"node_modules/yocto-queue": {
 			"version": "0.1.0",
-			"resolved": "https://mirrors.cloud.tencent.com/npm/yocto-queue/-/yocto-queue-0.1.0.tgz",
+			"resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
 			"integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
 			"dev": true,
 			"peer": true,


### PR DESCRIPTION
Currently, every `resolved` URL in `package-lock.json` points at `https://mirrors.cloud.tencent.com/npm/`
instead of the default registry. This makes the build fail for anyone who does not have `https://mirrors.cloud.tencent.com/npm/` configured as a mirror.

This PR changes the URLs to point to the default registry of `https://registry.npmjs.org/`. This fixed the local build for me, and it should make this project much more portable for different people working on it.

This should be a very safe change to merge as it just updates the registry URLs and doesn't change anything else.