### PR TITLE
Trigger quick-preview event on text edit

### DIFF
--- a/src/codeEditorView.ts
+++ b/src/codeEditorView.ts
@@ -30,6 +30,7 @@ export class CodeEditorView extends TextFileView {
 
 		this.monacoEditor.onDidChangeModelContent(() => {
 			this.requestSave();
+			this.app.workspace.trigger("quick-preview", this.file, this.monacoEditor.getValue());
 		});
 
 		this.addCtrlKeyWheelEvents();


### PR DESCRIPTION
This PR makes Obsidian's [quick-preview](https://docs.obsidian.md/Reference/TypeScript+API/Workspace/on('quick-preview')) event fire when an open code file is modified.

As far as I know, the only effect this has in unmodified Obsidian is to fix the word count and character count not updating immediately as you type. Before this PR, those counts only update when the note is opened and do not update live.

### Before

Look at the counts in the bottom right!

[Screencast_20260829_142857.webm](https://github.com/user-attachments/assets/a07a55df-5ab8-441d-aa0e-3ef245718339)

### After

[Screencast_20260829_143045.webm](https://github.com/user-attachments/assets/77f3e698-47dd-4a9d-9061-ba3c9575672d)
