### PR TITLE
Add "remember view state" feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ data.json
 .DS_Store
 
 
+# Saved view states from this plugin
+view-states.json

--- a/src/codeEditorView.ts
+++ b/src/codeEditorView.ts
@@ -38,12 +38,28 @@ export class CodeEditorView extends TextFileView {
 		// const model = this.monacoEditor.getModel();
 		// monaco.editor.setModelLanguage(model, this.getLanguage());
 		await super.onLoadFile(file);
+
+		if (this.plugin.settings.rememberViewState) {
+			this.monacoEditor.restoreViewState(this.plugin.viewStates.get(file.path));
+		}
 	}
 
 	async onUnloadFile(file: TFile) {
+		if (this.plugin.settings.rememberViewState)
+		{
+			this.saveViewState(file);
+			this.plugin.viewStates.writeAllStatesToDisk();
+		}
+
 		window.removeEventListener('keydown', this.keyHandle, true);
 		await super.onUnloadFile(file);
 		this.monacoEditor.dispose();
+	}
+
+	saveViewState(file = this.file) {
+		if (file) {
+			this.plugin.viewStates.set(file.path, this.monacoEditor.saveViewState());
+		}
 	}
 
 	async onClose() {
@@ -69,11 +85,13 @@ export class CodeEditorView extends TextFileView {
 	}
 
 	setViewData = (data: string, clear: boolean) => {
+		const previousViewState = this.monacoEditor.saveViewState();
 		if (clear) {
 			this.monacoEditor.getModel()?.setValue(data);
 		} else {
 			this.monacoEditor.setValue(data);
 		}
+		this.monacoEditor.restoreViewState(previousViewState);
 	}
 	clear = () => {
 		this.monacoEditor.setValue('');

--- a/src/codeFilesSettingsTab.ts
+++ b/src/codeFilesSettingsTab.ts
@@ -129,6 +129,16 @@ export class CodeFilesSettingsTab extends PluginSettingTab {
 					await this.plugin.saveSettings();
 				}));
 
+		new Setting(containerEl)
+			.setName(t('REMEMBER_VIEW_STATE'))
+			.setDesc(t('REMEMBER_VIEW_STATE_DESC'))
+			.addToggle(toggle => toggle
+				.setValue(this.plugin.settings.rememberViewState)
+				.onChange(async (value) => {
+					this.plugin.settings.rememberViewState = value;
+					await this.plugin.saveSettings();
+				}));
+
 
 
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -11,6 +11,7 @@ export interface EditorSettings {
 	fontSize: number;
 	fontFamily: string;
 	fontLigatures: boolean;
+	rememberViewState: boolean;
 }
 
 export const DEFAULT_SETTINGS: EditorSettings = {
@@ -25,6 +26,7 @@ export const DEFAULT_SETTINGS: EditorSettings = {
 	fontSize: 14,
 	fontFamily: "'Cascadia Code', 'Fira Code', Consolas, 'Courier New', monospace",
 	fontLigatures: true,
+	rememberViewState: false,
 }
 
 

--- a/src/lang/locale/en.ts
+++ b/src/lang/locale/en.ts
@@ -24,6 +24,8 @@ export default {
   MINIMAP_DESC: 'Editor will show a minimap.',
   WORDWRAP: 'Word wrap',
   WORDWRAP_DESC: 'Editor will wrap long lines.',
+  REMEMBER_VIEW_STATE: 'Remember view state',
+  REMEMBER_VIEW_STATE_DESC: 'Reopening a code file returns the cursor, scroll position and folded regions to where you left them.',
   CREATE_CODE: 'Create Code File',
   REGISTE_ERROR: 'VSCode Editor Plugin Error',
   REGISTE_ERROR_DESC: '{0}\nThere may already be other plugins registered with the same file extension. Please change the extension in the settings of the VSCode Editor Plugin or disable conflicting plugins.',

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ import { t } from 'src/lang/helpers';
 import { FenceEditModal } from "./fenceEditModal";
 import { FenceEditContext } from "./fenceEditContext";
 import { mountCodeEditor } from "./mountCodeEditor";
+import { ViewStates } from "./viewStates";
 
 declare module "obsidian" {
 	interface Workspace {
@@ -22,6 +23,7 @@ declare module "obsidian" {
 
 export default class CodeFilesPlugin extends Plugin {
 	settings: EditorSettings;
+	viewStates: ViewStates;
 
 	observer: MutationObserver;
 
@@ -37,6 +39,11 @@ export default class CodeFilesPlugin extends Plugin {
 
 	async onload() {
 		await this.loadSettings();
+
+		this.viewStates = new ViewStates(this);
+		await this.viewStates.load();
+		this.registerEvent(this.app.vault.on("rename", (file, oldPath) => this.viewStates.rename(file.path, oldPath)));
+		this.registerEvent(this.app.workspace.on("quit", () => this.saveViewStates()));
 
 		this.registerView(viewType, leaf => new CodeEditorView(leaf, this));
 
@@ -171,6 +178,17 @@ export default class CodeFilesPlugin extends Plugin {
 
 	onunload() {
 		this.observer.disconnect();
+		this.saveViewStates();
+	}
+
+	saveViewStates() {
+		if (this.settings.rememberViewState)
+		{
+			for (const leaf of this.app.workspace.getLeavesOfType(viewType)) {
+				(leaf.view as CodeEditorView).saveViewState();
+			}
+			this.viewStates.writeAllStatesToDisk();
+		}
 	}
 
 

--- a/src/viewStates.ts
+++ b/src/viewStates.ts
@@ -1,0 +1,49 @@
+
+import { Plugin } from "obsidian";
+import * as monaco from 'monaco-editor'
+
+/*
+Remembers where you left off in each code file. Monaco's view state holds the
+cursor, the selection, the scroll offset and which regions are folded, so
+restoring it puts the editor back exactly as it was.
+*/
+export class ViewStates {
+
+	private states: Record<string, monaco.editor.ICodeEditorViewState> = {};
+
+	constructor(private plugin: Plugin) { }
+
+	private get path() {
+		return `${this.plugin.manifest.dir}/view-states.json`;
+	}
+
+	async load() {
+		try {
+			const { adapter } = this.plugin.app.vault;
+			if (await adapter.exists(this.path)) {
+				this.states = JSON.parse(await adapter.read(this.path));
+			}
+		} catch (e) {
+			console.error("VSCode Editor plugin can't read saved view states: " + e);
+		}
+	}
+
+	get(path: string) {
+		return this.states[path];
+	}
+
+	set(path: string, state: monaco.editor.ICodeEditorViewState | null) {
+		if (state) {
+			this.states[path] = state;
+		}
+	}
+
+	rename(path: string, oldPath: string) {
+		this.states[path] = this.states[oldPath];
+		delete this.states[oldPath];
+	}
+
+	writeAllStatesToDisk() {
+		this.plugin.app.vault.adapter.write(this.path, JSON.stringify(this.states));
+	}
+}


### PR DESCRIPTION
This PR adds a new plugin setting, disabled by default, called "Remember view state". If enabled, the plugin will save the Monaco [view state](https://microsoft.github.io/monaco-editor/docs.html#interfaces/editor_editor_api.editor.ICodeEditorViewState.html) to a json file when a code file is closed. It will also save the state of all open code files when Obsidian quits.

The code works similarly to the [Remember Cursor Position](https://github.com/dy-sh/obsidian-remember-cursor-position) plugin.

The Monaco view state holds the cursor position, the selection, the scroll offset, and which regions are folded, so this feature allows you to pick up right where you left off when leaving and coming back to files. Here's a demonstration video:

[Screencast_20260830_071409.webm](https://github.com/user-attachments/assets/19419369-9b96-4d05-aad5-ea21255c0077)

Closes #71